### PR TITLE
recursively search video files

### DIFF
--- a/check_missing_videos.py
+++ b/check_missing_videos.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     print('{} videos in dataset.'.format(len(videos_dataset)))
 
     # index video files
-    video_files = glob.glob(os.path.join(args.root_dir, '*', '*.mp4'))
+    video_files = glob.glob(os.path.join(args.root_dir, '**', '*.mp4'), recursive=True)
     videos_exist = set()
     for video in video_files:
         items = video.split('/')


### PR DESCRIPTION
In some cases, video files may not reside in a single folder. For example, ppl may organize videos in different folders based on dataset split. In such case, we should search video files recursively.